### PR TITLE
Attempt to fix netmgrd crashes

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -376,3 +376,4 @@ on property:sys.sn_set=1
 on property:sys.boot_completed=1
     restart ril-daemon
     restart ril-daemon2
+    restart netmgrd

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -244,7 +244,7 @@ service qmuxd /system/bin/qmuxd
 
 service netmgrd /system/bin/netmgrd
     class main
-    group system
+    group system wakelock
 
 service sensord /system/bin/sensord
     class main

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -371,3 +371,8 @@ service set_sn /system/bin/adjust_serialno setsn
 
 on property:sys.sn_set=1
     start set_sn
+
+# This fixes broken data connection on netmgrd crash
+on property:sys.boot_completed=1
+    restart ril-daemon
+    restart ril-daemon2

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -244,6 +244,7 @@ service qmuxd /system/bin/qmuxd
 
 service netmgrd /system/bin/netmgrd
     class main
+    group system
 
 service sensord /system/bin/sensord
     class main

--- a/sepolicy/rild.te
+++ b/sepolicy/rild.te
@@ -1,0 +1,4 @@
+allow rild self:capability dac_override;
+
+allow rild proc_net:file write;
+allow rild system_app_data_file:dir search;


### PR DESCRIPTION
Don't merge this, I will push it through Gerrit once I'm sure that this works.

These commits should fix the netmgrd crash when switching from Wifi to mobile data. It's hard to reproduce, but I've documented the needed steps here:
https://jira.lineageos.org/browse/BUGBASH-72

Please try out these changes on latest LineageOS 14.1 and see if it solves the issue. Looking forward to your feedback!